### PR TITLE
[WIP] Correct Path Variables for Install Location

### DIFF
--- a/automatic/android-sdk.install/android-sdk.nuspec
+++ b/automatic/android-sdk.install/android-sdk.nuspec
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>{{PackageName}}</id>
+    <title>Android SDK</title>
+    <version>{{Version}}</version>
+    <authors>Google</authors>
+    <owners>Justin James</owners>
+    <summary>The Android SDK provides you the API libraries and developer tools necessary to build, test, and debug apps for Android.</summary>
+    <description>The Android SDK provides you the API libraries and developer tools necessary to build, test, and debug apps for Android.
+    </description>
+    <projectUrl>https://developer.android.com/studio/index.html</projectUrl>
+    <tags>android sdk google admin</tags>
+    <copyright>Google</copyright>
+    <licenseUrl>https://developer.android.com/license.html</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/digitaldrummerj/ChocolateyPackages/master/automatic/android-sdk/android.svg</iconUrl>
+    <dependencies>
+      <dependency id="jdk8"  />
+    </dependencies>
+    <packageSourceUrl>https://github.com/digitaldrummerj/ChocolateyPackages</packageSourceUrl>
+    <releaseNotes>Release Notes: [https://developer.android.com/studio/releases/sdk-tools.html](https://developer.android.com/studio/releases/sdk-tools.html)
+    
+### Chocolatey Package Change Log:
+
+* 8-12-2016: Added checksums
+
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <!--<file src="content\**" target="content" />-->
+  </files>
+</package>

--- a/automatic/android-sdk.install/android.svg
+++ b/automatic/android-sdk.install/android.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-147 -68 294 343">
+<g fill="#a4c639">
+<use stroke-width="14.4" xlink:href="#b" stroke="#FFF"/>
+<use xlink:href="#a" transform="scale(-1,1)"/>
+<g id="a" stroke="#FFF" stroke-width="7.2">
+<rect rx="6.5" transform="rotate(29)" height="86" width="13" y="-86" x="14"/>
+<rect id="c" rx="24" height="133" width="48" y="41" x="-143"/>
+<use y="97" x="85" xlink:href="#c"/>
+</g>
+<g id="b">
+<ellipse cy="41" rx="91" ry="84"/>
+<rect rx="22" height="182" width="182" y="20" x="-91"/>
+</g>
+</g>
+<g stroke="#FFF" stroke-width="7.2" fill="#FFF">
+<path d="m-95 44.5h190"/><circle cx="-42" r="4"/><circle cx="42" r="4"/>
+</g>
+</svg>

--- a/automatic/android-sdk.install/tools/chocolateyInstall.ps1
+++ b/automatic/android-sdk.install/tools/chocolateyInstall.ps1
@@ -1,0 +1,15 @@
+﻿$downUrl = '{{DownloadUrl}}'
+$checksum = '{checksum}'
+$checksumType = 'sha256'
+Install-ChocolateyPackage '{{PackageName}}' 'exe' '/S' '/ALLUSERS=1' $downUrl -validExitCodes @(0)  -Checksum "$checksum" -ChecksumType "$checksumType"
+
+if ("${Env:ProgramFiles(x86)}")
+{
+    Install-ChocolateyPath "${Env:ProgramFiles(x86)}\Android\android-sdk\tools" 'Machine'
+	Install-ChocolateyPath "${Env:ProgramFiles(x86)}\Android\android-sdk\platform-tools" 'Machine'
+}
+else
+{
+	Install-ChocolateyPath "${Env:ProgramFiles}\Android\android-sdk\tools" 'Machine'
+    Install-ChocolateyPath "${Env:ProgramFiles}\Android\android-sdk\platform-tools" 'Machine'
+}

--- a/automatic/android-sdk.install/tools/chocolateyUninstall.ps1
+++ b/automatic/android-sdk.install/tools/chocolateyUninstall.ps1
@@ -1,0 +1,8 @@
+﻿
+UnInstall-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\tools" 'Machine'
+UnInstall-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\platform-tools" 'Machine'
+
+$packageName = '{{PackageName}}'
+$unpath = "${Env:LOCALAPPDATA}\Android\android-sdk\uninstall.exe"
+Uninstall-ChocolateyPackage $packageName 'exe' '/S' $unpath
+  

--- a/automatic/android-sdk/tools/chocolateyInstall.ps1
+++ b/automatic/android-sdk/tools/chocolateyInstall.ps1
@@ -1,13 +1,7 @@
 ﻿$downUrl = '{{DownloadUrl}}'
 $checksum = '{checksum}'
 $checksumType = 'sha256'
-Install-ChocolateyPackage '{{PackageName}}' 'exe' '/S' $downUrl -validExitCodes @(0)  -Checksum "$checksum" -ChecksumType "$checksumType"
+Install-ChocolateyPackage '{{PackageName}}' 'exe' '/S' $downUrl -validExitCodes @(0)   -Checksum "$checksum" -ChecksumType "$checksumType"
 
-if ("${Env:ProgramFiles(x86)}")
-{
-    Install-ChocolateyPath "${Env:ProgramFiles(x86}\Android\android-sdk\tools" 'Machine'
-}
-else
-{
-    Install-ChocolateyPath "${Env:ProgramFiles}\Android\android-sdk\platform-tools" 'Machine'
-}
+Install-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\tools" 'Machine'
+Install-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\platform-tools" 'Machine'

--- a/automatic/android-sdk/tools/chocolateyInstall.ps1
+++ b/automatic/android-sdk/tools/chocolateyInstall.ps1
@@ -1,7 +1,13 @@
 ﻿$downUrl = '{{DownloadUrl}}'
 $checksum = '{checksum}'
 $checksumType = 'sha256'
-Install-ChocolateyPackage '{{PackageName}}' 'exe' '/S' $downUrl -validExitCodes @(0)   -Checksum "$checksum" -ChecksumType "$checksumType"
+Install-ChocolateyPackage '{{PackageName}}' 'exe' '/S' $downUrl -validExitCodes @(0)  -Checksum "$checksum" -ChecksumType "$checksumType"
 
-Install-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\tools" 'Machine'
-Install-ChocolateyPath "${Env:LOCALAPPDATA}\Android\android-sdk\platform-tools" 'Machine'
+if ("${Env:ProgramFiles(x86)}")
+{
+    Install-ChocolateyPath "${Env:ProgramFiles(x86}\Android\android-sdk\tools" 'Machine'
+}
+else
+{
+    Install-ChocolateyPath "${Env:ProgramFiles}\Android\android-sdk\platform-tools" 'Machine'
+}


### PR DESCRIPTION
The install was not installing to `${Env:LOCALAPPDATA}\Android\android-sdk` but was instead installing to `${Env:ProgramFiles(x86)}\Android\android-sdk\tools` or`${Env:ProgramFiles}\Android\android-sdk\platform-tools`.  This corrects the path location.