### PR TITLE
Update AndroidStudio to 2.3.3.0 and fix Desktop Shortcut Install

### DIFF
--- a/AndroidStudio/AndroidStudio.nuspec
+++ b/AndroidStudio/AndroidStudio.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>AndroidStudio</id>
-        <version>2.3.1.0</version>
+        <version>2.3.3.0</version>
         <title>Android Studio</title>
         <authors>Google</authors>
         <owners>Justin James</owners>

--- a/AndroidStudio/tools/chocolateyInstall.ps1
+++ b/AndroidStudio/tools/chocolateyInstall.ps1
@@ -36,7 +36,14 @@ $studioExe = GetStudioExe
 if ($settings.addtodesktop -eq "true")
 {
 	Write-Host "AddToDesktop Value: " $settings.addtodesktop
-	Install-ChocolateyShortcut $studioExe
+	
+    $desktopPath = [Environment]::GetFolderPath("Desktop")
+    $iconPath = Join-Path $(Split-Path $studioExe) 'studio.ico'
+    
+    Install-ChocolateyShortcut `
+        -ShortcutFilePath "$desktopPath\$package.lnk" `
+        -TargetPath "$studioExe" `
+        -IconLocation "$iconPath"
 }
 
 if ($settings.pinnedtotaskbar -eq "true")

--- a/AndroidStudio/tools/common.ps1
+++ b/AndroidStudio/tools/common.ps1
@@ -1,7 +1,7 @@
 ﻿$package = 'AndroidStudio'
-$majorVersion = '2.3.1.0'
-$buildVersion = '162.3871768'
-$checksum = '95ca44467d399e609e86bf874eba00f8f2e6e371ae294b7f1e88cfc8689e14dd'
+$majorVersion = '2.3.3.0'
+$buildVersion = '162.4069837'
+$checksum = 'f0b72473cb94ba4bcbc80eeb84f4b53364da097efa255f7cab71bcb10a28775a'
 $extractionPath =  Join-Path  $env:programfiles 'Android'
 $installDir = Join-Path $extractionPath 'Android Studio'
 


### PR DESCRIPTION
- Updated AndroidStudio to 2.3.3.0
- Installation of Desktop Shortcut was failing. Fixed that. 