### PR TITLE
Update android-sdk install script to fix an error

### DIFF
--- a/android-sdk/tools/chocolateyInstall.ps1
+++ b/android-sdk/tools/chocolateyInstall.ps1
@@ -7,4 +7,4 @@ Install-ChocolateyPath $envPlatformsPath 'Machine'
 Install-ChocolateyEnvironmentVariable 'ANDROID_HOME' ${envPath} 'Machine'
 refreshenv
 
-echo yes | android update sdk --filter tools,platform-tools --all --no-ui
+echo yes | android update sdk --filter tools --filter platform-tools --all --no-ui


### PR DESCRIPTION
Fix this error which happens with android-sdk 25.2.3.1: Argument 'platform-tools' is not recognized.