### PR TITLE
switched from jdk8 to adoptopenjdk8 dependency

### DIFF
--- a/android-sdk/android-sdk.nuspec
+++ b/android-sdk/android-sdk.nuspec
@@ -21,7 +21,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/digitaldrummerj/ChocolateyPackages/master/automatic/android-sdk/android.svg</iconUrl>
     <dependencies>
-      <dependency id="jdk8"  />
+      <dependency id="adoptopenjdk8"  />
     </dependencies>
     <packageSourceUrl>https://github.com/digitaldrummerj/ChocolateyPackages</packageSourceUrl>
     <releaseNotes>Release Notes: [https://developer.android.com/studio/releases/sdk-tools.html](https://developer.android.com/studio/releases/sdk-tools.html)


### PR DESCRIPTION
reason: jdk8 will not receive any further updates (see https://chocolatey.org/packages/jdk8#comment-4765826820)